### PR TITLE
Fixed Turkish charmap

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -332,10 +332,10 @@
         'İ': 'I',
         // 'ç': 'c', // duplicate
         // 'Ç': 'C', // duplicate
-        // 'ü': 'ue', // duplicate
-        // 'Ü': 'Ue', // duplicate
-        // 'ö': 'oe', // duplicate
-        // 'Ö': 'Oe', // duplicate
+        'ü': 'u',
+        'Ü': 'U',
+        'ö': 'o',
+        'Ö': 'O',
         'ğ': 'g',
         'Ğ': 'G',
 


### PR DESCRIPTION
Turkish use of phonetics and Turkish/Latin text entry/reading require that just the hyphens get removed. Therefore a representation of `'Ü'` as `'Ue'` is wrong where it should have been `'U'` hence the edited fixes.
