### PR TITLE
Minor grammar typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Usage
 -	`options` {object}
 
 	-	`separator` {string} default: '-'
-		-	char that replace the whitespaces
+		-	char that replaces the whitespaces
 	-	`lang` {string} default: 'en' // ISO 639-1 Codes
 		-	language specific transliteration (
 			-	'ar' // Arabic


### PR DESCRIPTION
I'm a native Scottish English speaker, so I might be wrong, but I'm 99% sure it should be "replaces" and not "replace". :-)