### PR TITLE
Fix sprockets-rails 3.0

### DIFF
--- a/lib/speakingurl-rails.rb
+++ b/lib/speakingurl-rails.rb
@@ -5,7 +5,8 @@ module Speakingurl
     class Railtie < ::Rails::Railtie
       initializer "speakingurl_rails.append_path", :group => :all do |app|
         speakingurl_path =  File.expand_path('../', __FILE__)
-        app.assets.prepend_path(speakingurl_path.to_s)
+        sprockets_env = app.assets || app.config.assets # sprockets-rails 3.x attaches this at a different config
+        sprockets_env.prepend_path(speakingurl_path.to_s)
       end
     end
   end


### PR DESCRIPTION
Hello, this is a fix to be able to use sprocket-rails 3.0.0.