### PR TITLE
Improved README (yarn install option, https links, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ bower install --save speakingurl
 component install pid/speakingurl
 ```
 
-#### [jamjs](http://jamjs.org/)
-
-```shell
-jam install speakingurl
-```
-
 #### [Ruby on Rails](http://rubyonrails.org/)
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ SpeakingURL
 ===========
 
 [![Build Status](https://travis-ci.org/pid/speakingurl.svg)](https://travis-ci.org/pid/speakingurl) 
-[![NPM version](https://badge.fury.io/js/speakingurl.svg)](http://badge.fury.io/js/speakingurl) 
-[![Bower version](https://badge.fury.io/bo/speakingurl.svg)](http://badge.fury.io/bo/speakingurl) 
-[![Gem Version](https://badge.fury.io/rb/speakingurl-rails.svg)](http://badge.fury.io/rb/speakingurl-rails) 
+[![NPM version](https://badge.fury.io/js/speakingurl.svg)](https://badge.fury.io/js/speakingurl) 
+[![Bower version](https://badge.fury.io/bo/speakingurl.svg)](https://badge.fury.io/bo/speakingurl) 
+[![Gem Version](https://badge.fury.io/rb/speakingurl-rails.svg)](https://badge.fury.io/rb/speakingurl-rails) 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pid/speakingurl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) 
-[![Flattr](http://api.flattr.com/button/flattr-badge-large.png)](http://flattr.com/thing/1418477/pidspeakingurl-on-GitHub)
+[![Flattr](https://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/thing/1418477/pidspeakingurl-on-GitHub)
 
 
 > Generate a slug with a lot of options; create a so-called [Semantic URL](https://en.wikipedia.org/wiki/Semantic_URL) or 'Clean URL' or 'Pretty URL' or 'nice-looking URL' or 'Speaking URL' or 'user-friendly URL' or 'SEO-friendly URL' from a string. This module aims to transliterate the input string.
@@ -32,7 +32,7 @@ npm install speakingurl --save
 yarn add speakingurl --dev
 ```
 
-#### [Bower](http://bower.io)
+#### [Bower](https://bower.io)
 
 ```shell
 bower install --save speakingurl
@@ -59,14 +59,14 @@ copy the file speakingurl.min.js to your script directory
 
 available versions:
 
--	[www.cdnjs.com/libraries/speakingurl/](http://cdnjs.com/libraries/speakingurl/)
+-	[www.cdnjs.com/libraries/speakingurl/](https://cdnjs.com/libraries/speakingurl/)
 -	use [//cdnjs.cloudflare.com/ajax/libs/speakingurl/10.0.0/speakingurl.min.js](https://cdnjs.cloudflare.com/ajax/libs/speakingurl/10.0.0/speakingurl.min.js)
 
 #### [CDN/maxcdn](https://www.maxcdn.com/)
 
 available versions:
 
--	[www.jsdelivr.com/#!speakingurl](]http://www.jsdelivr.com/#!speakingurl)
+-	[www.jsdelivr.com/#!speakingurl](https://www.jsdelivr.com/#!speakingurl)
 -	use [//cdn.jsdelivr.net/speakingurl/10.0.0/speakingurl.min.js](https://cdn.jsdelivr.net/speakingurl/10.0.0/speakingurl.min.js)
 
 Usage
@@ -382,8 +382,8 @@ $ gem push speakingurl-rails-x.x.x.gem
 References
 ----------
 
--	http://tools.ietf.org/html/rfc3986
--	http://en.wikipedia.org/wiki/Transliteration
+-	https://tools.ietf.org/html/rfc3986
+-	https://en.wikipedia.org/wiki/Transliteration
 
 Use in other environments
 -------------------------

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Installation
 npm install speakingurl --save
 ```
 
+#### [yarn](https://yarnpkg.com)
+
+```shell
+yarn add speakingurl --dev
+```
+
 #### [Bower](http://bower.io)
 
 ```shell


### PR DESCRIPTION
This PR does three things:

* Adds `yarn` install option.
* Removes now obsolete `jamjs` install option.
* Convert all links in `README.md` to `https` if available.