### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ available versions:
 
 available versions:
 
--	[www.jsdelivr.com/#!speakingurl](https://www.jsdelivr.com/#!speakingurl)
--	use [//cdn.jsdelivr.net/speakingurl/14.0.1/speakingurl.min.js](https://cdn.jsdelivr.net/speakingurl/14.0.1/speakingurl.min.js)
+-	[www.jsdelivr.com/#!speakingurl](https://www.jsdelivr.com/package/npm/speakingurl)
+-	use [//cdn.jsdelivr.net/npm/speakingurl@14.0.1/speakingurl.min.js](https://cdn.jsdelivr.net/npm/speakingurl@14.0.1/speakingurl.min.js)
 
 Usage
 -----

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "speakingurl",
     "version": "14.0.1",
     "description": "Generate a slug – transliteration with a lot of options",
-	"jsdelivr": "speakingurl.min.js",
+    "jsdelivr": "speakingurl.min.js",
     "homepage": "http://pid.github.io/speakingurl/",
     "github": "http://github.com/pid/speakingurl",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "speakingurl",
     "version": "14.0.1",
     "description": "Generate a slug – transliteration with a lot of options",
+	"jsdelivr": "speakingurl.min.js",
     "homepage": "http://pid.github.io/speakingurl/",
     "github": "http://github.com/pid/speakingurl",
     "repository": {


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.
I also changed the default file to `speakingurl.min.js`

You can find links for all files at https://www.jsdelivr.com/package/npm/speakingurl.

Feel free to ping me if you have any questions regarding this change.