### PR TITLE
empty separator passed in options object works as passed directly

### DIFF
--- a/lib/speakingurl.js
+++ b/lib/speakingurl.js
@@ -1466,7 +1466,7 @@
             uricNoSlashFlag = opts.uricNoSlash || false;
             markFlag = opts.mark || false;
             convertSymbols = (opts.symbols === false || opts.lang === false) ? false : true;
-            separator = opts.separator || separator;
+            separator = typeof opts.separator !== 'undefined' ? opts.separator : separator;
 
             if (uricFlag) {
                 allowedChars += uricChars;

--- a/test/test-separator.js
+++ b/test/test-separator.js
@@ -170,6 +170,21 @@ describe('getSlug separator', function () {
 
     });
 
+    it('should work the same regardless the method it was passed', function (done) {
+        // given
+        var testString = '-ä ß üö,.';
+        var emptySeparator = '';
+
+        // when
+        var resultAsOption = getSlug(testString, { separator: emptySeparator });
+        var resultDirect = getSlug(testString, emptySeparator);
+
+        // then
+        resultAsOption.should.eql(resultDirect);
+
+        done();
+    });
+
     it('should return empty string because of non string input', function (done) {
 
         getSlug(true)


### PR DESCRIPTION
Hi, thats my take on #116. 