### PR TITLE
Allow custom replace for >1 char non-latin keys

### DIFF
--- a/lib/speakingurl.js
+++ b/lib/speakingurl.js
@@ -1509,11 +1509,7 @@
             Object.keys(customReplacements).forEach(function (v) {
                 var r;
 
-                if (v.length > 1) {
-                    r = new RegExp('\\b' + escapeChars(v) + '\\b', 'gi');
-                } else {
-                    r = new RegExp(escapeChars(v), 'gi');
-                }
+                r = new RegExp(escapeChars(v), 'gi');
 
                 input = input.replace(r, customReplacements[v]);
             });


### PR DESCRIPTION
This fixes the issue where custom mapping fails for non-latin keys with a length of more than 1 character. 
#122 